### PR TITLE
支持加载Plugin时，指定IContainerContext的实现

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,9 +43,9 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v2
       with:
-        java-version: 8
+        java-version: '8'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '8'
+        distribution: 'adopt'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,11 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - name: Setup Java JDK
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 8
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild

--- a/dddplus-spec/src/main/java/io/github/dddplus/plugin/IContainerContext.java
+++ b/dddplus-spec/src/main/java/io/github/dddplus/plugin/IContainerContext.java
@@ -18,7 +18,7 @@ public interface IContainerContext {
      * @param requiredType type the bean must match; can be an interface or superclass
      * @param <T>
      * @return an instance of the single bean matching the required type
-     * @throws RuntimeException
+     * @throws RuntimeException if the bean could not be obtained
      */
     <T> T getBean(@NotNull Class<T> requiredType) throws RuntimeException;
 
@@ -29,7 +29,7 @@ public interface IContainerContext {
      * @param requiredType type the bean must match; can be an interface or superclass
      * @param <T>
      * @return an instance of the bean
-     * @throws RuntimeException
+     * @throws RuntimeException if the bean could not be obtained
      */
     <T> T getBean(@NotNull String name, @NotNull Class<T> requiredType) throws RuntimeException;
 


### PR DESCRIPTION
默认的实现暴露给前台(Partner)的spring getBean，理论上前台可以获取中台的任意spring bean。
不同场景下，前中台的信任关系是不同的，需要一种控制前台受控获取spring bean的机制。

本方案，提供了这样的机制。
但具体的受控策略，需要使用者实现 IContainerContext 来实现