### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.2.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
         <slf4j.version>1.7.25</slf4j.version>
         <junit.version>4.13.1</junit.version>
         <archunit.version>0.13.1</archunit.version>
-        <spring.version>4.3.12.RELEASE</spring.version>
+        <spring.version>5.2.21</spring.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 4.3.12.RELEASE
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 4.3.12.RELEASE to 5.2.21 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS