### PR TITLE
Alter assertion on tag to fix flaky test exportDomainArtifacts

### DIFF
--- a/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
+++ b/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
@@ -614,7 +614,8 @@ public class IntegrationTest {
         assertTrue(artifacts.getSteps().containsKey(Steps.Submit.Activity));
         List<DomainArtifacts.Step> submitSteps = artifacts.getSteps().get(Steps.Submit.Activity);
         assertEquals(4, submitSteps.size()); // FooStep, BarStep, BazStep, HamStep
-        assertEquals(Steps.Submit.GoodsValidationGroup, submitSteps.get(0).getTags()[0]);
+        assertTrue(submitSteps.stream().anyMatch(step -> step.getTags().length > 0 &&
+            step.getTags()[0].equals(Steps.Submit.GoodsValidationGroup)));
 
         // extensions: IFooExt IMultiMatchExt IReviseStepsExt IDecideStepsExt IPartnerExt IPatternOnlyExt
         assertEquals(7, artifacts.getExtensions().size());


### PR DESCRIPTION
This PR is to fix a flaky test `io.github.dddplus.runtime.registry.IntegrationTest#exportDomainArtifacts`.
#### Setup:
Java version: 1.8.0_382
Maven version: Apache Maven 3.6.3

#### Test failure Reproduction
The test `io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts` is flaky as the underlying code uses a HashMap and assumes the order of values returned by the `.values()` function. This flaky behavior was verified using the NonDex [plugin](https://github.com/TestingResearchIllinois/NonDex).  

Steps:
1. Clone repo: `git clone https://github.com/funkygao/cp-ddd-framework`
2. `cd cp-ddd-framework`
3. Compile the module: `mvn install -pl dddplus-test -am -DskipTests`
4. Nondex tool run cmd: ```mvn -pl dddplus-test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.github.dddplus.runtime.registry.IntegrationTest#exportDomainArtifacts```

Non dex test failure:
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.002 s <<< FAILURE! - in io.github.dddplus.runtime.registry.IntegrationTest
[ERROR] io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts  Time elapsed: 0.001 s  <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: 0
	at io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts(IntegrationTest.java:617)
```
The tool flags the test as failed even in the `ONE` mode, which means that the map's keys are shuffled only once and every call to the map produces the same shuffled order.

#### Root cause and fix
The test has been setup to register 4 submit activities with codes Bar, Baz, Foo and Ham as indicated by debug logs:

```
2023-09-23 10:28:19,966 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Bar, name=, tags=[goodsValidation], stepBean=io.github.dddplus.runtime.registry.mock.step.BarStep@2d8f2f3a) 
2023-09-23 10:28:19,980 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Baz, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.BazStep@2024293c) 
2023-09-23 10:28:19,981 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Cancel, code=Egg, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.EggStep@7048f722) 
2023-09-23 10:28:19,992 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Foo, name=foo活动, tags=[goodsValidation], stepBean=io.github.dddplus.runtime.registry.mock.step.FooStep@58a55449) 
2023-09-23 10:28:19,994 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Ham, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.HamStep@5949eba8) 


```
Only Foo and Bar steps have a `goodsValidation` tag. 

The step objects for a specific activity (Submit in this [case](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java#L615)), are added as a list of values to a map, with key as activity [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/DomainArtifacts.java#L61). The 1st element of this list is asserted to have a `goodsValidation` tag in the test [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java#L617). This expectation fails when the first element of the list is neither Foo nor Bar. 

The way in which the list is populated will not guarantee any order leading to a flaky behavior

`InternalIndexer.domainStepDefMap` (a map of <k=activity name, hashmap{k=activityCode, v=step information}>), is an internal representation [link](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/InternalIndexer.java#L31). The list under question is populated by accessing InternalIndexer.domainStepDefMap map using key=Submit(activity name) and calling `.values()` on the value [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/DomainArtifacts.java#L60). The value is a hashmap(unordered) [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/master/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/InternalIndexer.java#L223) which guarantees no ordering among the values/steps. 

To fix the test expectation, we only filter for steps that have a non empty tag and assert that any of these steps tags have a value of `goodsValidation`, instead of the first one. This removes test flakiness with minimal changes. The change does not look at which specific step has this tag because the original test does not do the same. The original test is also agnostic if whether one or more steps has a tag. The change continues to maintain this test logic

The test was rerun using the Nondex plugin and passes after the fix.
